### PR TITLE
1.Added delay in creation of bastion service to allow bastion agent o…

### DIFF
--- a/bastion.tf
+++ b/bastion.tf
@@ -1,7 +1,21 @@
 ## Copyright © 2021, Oracle and/or its affiliates. 
 ## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
 
+
+resource "time_sleep" "wait_2min" {
+  depends_on = [
+    oci_core_instance.ror-server
+  ]
+  create_duration = "240s"
+}
+
+
+
 resource "oci_bastion_bastion" "bastion-service" {
+
+   depends_on = [
+    time_sleep.wait_2min
+  ]
   count                        = var.use_bastion_service ? 1 : 0
   bastion_type                 = "STANDARD"
   compartment_id               = var.compartment_ocid

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,7 @@
 
 output "generated_ssh_private_key" {
   value     = tls_private_key.public_private_key_pair.private_key_pem
-  sensitive = false
+  sensitive = true
 }
 
 output "railsapp_url" {

--- a/scripts/ror_bootstrap.sh
+++ b/scripts/ror_bootstrap.sh
@@ -1,11 +1,12 @@
 
 ## Copyright © 2021, Oracle and/or its affiliates. 
 ## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+#!/bin/bash 
 
-#!/bin/bash
 #install ruby manager, mysql-client and other dependencies
 sudo apt update
 sudo apt-get install -y build-essential git libsqlite3-dev libssl-dev libzlcore-dev mysql-client libmysqlclient-dev git-core zlib1g-dev build-essential libssl-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common libffi-dev nodejs npm
+
 
 
 #install yarn
@@ -15,34 +16,13 @@ echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/source
 sudo apt update
 sudo apt install -y yarn
 
-#Install rbenv ruby package manager
-cd
-git clone https://github.com/rbenv/rbenv.git ~/.rbenv
-echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bash_profile
-echo 'eval "$(rbenv init - bash)"' >> ~/.bash_profile
-source ~/.bash_profile
-
-git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
-echo 'export PATH="$HOME/.rbenv/plugins/ruby-build/bin:$PATH"' >> ~/.bash_profile
-source ~/.bash_profile
-
-#install ruby 3.0.1
-#todo make it a param in ORM
-
-rbenv install 3.0.1
-rbenv global 3.0.1
+sudo apt-get install -y ruby-full
+sudo gem install rails
 ruby -v
 
-#install ruby version 3.0.1
-
-#Use version 3.0.1 and make it default
-rbenv local 3.0.1
-source ~/.bash_profile
-#make sure that the ruby execs are used
-
 #Install rails and bundler gems
-gem install rails
-gem install bundler
+sudo gem install rails
+sudo gem install bundler
 
 #create an app
 sudo mkdir /opt/apps
@@ -54,10 +34,22 @@ rails new myapp -d mysql
 sudo iptables -I INPUT 6 -m state --state NEW -p tcp --dport 8080 -j ACCEPT
 
 #move database config to the application
-cd myapp
+cd /opt/apps/myapp/
 mv /home/ubuntu/database.yml /opt/apps/myapp/config/database.yml
-rake db:create
-rake db:migrate
+rake db:create 
+rake db:migrate  
 
-#start rails server bind all interfaces
-rails s -p 8080 -b 0.0.0.0 >> ./log/startup.log &
+# move database config to the application
+sudo chmod +x /home/ubuntu/start_rails.sh
+sudo mv /home/ubuntu/start_rails.sh /opt/apps/myapp/
+
+
+#add start_rails as a service
+sudo mv /home/ubuntu/shellscript.service /lib/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable shellscript.service 
+sudo systemctl start shellscript.service
+
+
+
+

--- a/scripts/shellscript.service
+++ b/scripts/shellscript.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=start rails
+
+[Service]
+ExecStart=/opt/apps/myapp/start_rails.sh start
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/start_rails.sh
+++ b/scripts/start_rails.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd /opt/apps/myapp
+sudo rails s  -p 8080 -b 0.0.0.0

--- a/variables.tf
+++ b/variables.tf
@@ -6,16 +6,29 @@ variable "release" {
   default     = "1.6"
 }
 
-variable "tenancy_ocid" {}
-variable "region" {}
-variable "compartment_ocid" {}
+variable "tenancy_ocid" {
+  type = string
+  default= ""
+}
+variable "region" {
+  type = string
+  default = ""
+}
+variable "compartment_ocid" {
+  type = string
+  default = ""
+  }
 #variable "fingerprint" {}
 #variable "user_ocid" {}
 #variable "private_key_path" {}
 variable "availablity_domain_name" {
+  type= string
   default = ""
 }
-variable "mysql_db_system_admin_password" {}
+variable "mysql_db_system_admin_password" {
+type = string
+default = ""
+}
 
 variable "use_bastion_service" {
   default = true


### PR DESCRIPTION
1. Added delay in the creation of bastion service to allow bastion agent on VM to come up first before creating the service.

2. Changed the bootstrap script to install Ruby without rbenv. The source command does not work with non-interactive shells so installation of rbenv was failing. I think I have a workaround for this. I’ll test it and add it to the next update.

3. Changed sudo rails s -p 8080 -b 0.0.0.0 & to be a service instead. The terraform remote-exec shell works differently
than typical ssh. When the remote-exec dies so does all processes it spawns. I tried nohup and disown.
Changing the start of the service to a systemctl fixed the issue.